### PR TITLE
Add Node.js setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ Installation for Google Cloud SDK (`gcloud`, `gsutil`, `cloud_sql_proxy`, etc.) 
 ```bash
 bash ~/dotfiles/scripts/setup_gcloud.sh
 ```
+
+### Node.js via NVM
+
+To install the latest LTS version of Node.js using [nvm](https://github.com/nvm-sh/nvm), run:
+
+```bash
+bash ~/dotfiles/scripts/setup_node.sh
+```
+

--- a/scripts/setup_node.sh
+++ b/scripts/setup_node.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to install Node.js using nvm (Node Version Manager)
+# This keeps Node installation separate from system packages
+
+set -e
+
+# Install nvm if not already present
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  echo "nvm already installed."
+else
+  echo "Installing nvm..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+
+# Load nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# Install and use latest LTS Node.js
+if command -v nvm > /dev/null; then
+  nvm install --lts
+  nvm use --default --lts
+fi
+


### PR DESCRIPTION
## Summary
- add `setup_node.sh` for installing Node via nvm
- document Node setup in README

## Testing
- `shellcheck scripts/setup_node.sh` *(fails: command not found)*
- `sudo apt-get update` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6884d217acbc8326a4aebe247c8e9d56