### PR TITLE
fix(zshrc): remove hardcoded usernames and guard Android Studio Java path

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -148,6 +148,9 @@ export LANG=ja_JP.UTF-8
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 source ~/dotfiles/.zshrc.alias
 
+# iTerm2 Shell Integration
+# コマンドの成功/失敗マーク表示、出力範囲のクリック選択、プロンプト間ジャンプ等を有効化
+# ファイルが存在する場合のみ読み込む（未インストール環境でもエラーにならない）
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # The following lines have been added by Docker Desktop to enable Docker CLI completions.
@@ -178,3 +181,5 @@ fi
 
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
+
+. "$(brew --prefix asdf)/libexec/asdf.sh"

--- a/.zshrc
+++ b/.zshrc
@@ -8,8 +8,8 @@ elif [ -f '/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.
   source '/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc'
 elif [ -f '/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc' ]; then
   source '/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc'
-elif [ -f '/Users/yamadaken/google-cloud-sdk/path.zsh.inc' ]; then
-  source '/Users/yamadaken/google-cloud-sdk/path.zsh.inc'
+elif [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
+  source "$HOME/google-cloud-sdk/path.zsh.inc"
 fi
 
 if [ -f '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc' ]; then
@@ -20,8 +20,8 @@ elif [ -f '/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/compl
   source '/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc'
 elif [ -f '/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc' ]; then
   source '/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc'
-elif [ -f '/Users/yamadaken/google-cloud-sdk/completion.zsh.inc' ]; then
-  source '/Users/yamadaken/google-cloud-sdk/completion.zsh.inc'
+elif [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then
+  source "$HOME/google-cloud-sdk/completion.zsh.inc"
 fi
 
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
@@ -154,13 +154,13 @@ source ~/dotfiles/.zshrc.alias
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # The following lines have been added by Docker Desktop to enable Docker CLI completions.
-fpath=(/Users/yamadaken/.docker/completions $fpath)
+fpath=($HOME/.docker/completions $fpath)
 autoload -Uz compinit
 compinit
 # End of Docker CLI completions
 
 # Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/yamadaken/.lmstudio/bin"
+export PATH="$PATH:$HOME/.lmstudio/bin"
 
 
 
@@ -179,7 +179,13 @@ if [ -d "$HOME/.anyenv" ]; then
     fi
 fi
 
-# Added by Antigravity
-export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
+# Android StudioのJavaを優先（インストール済みの場合のみ）
+_AS_JAVA="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+if [ -d "$_AS_JAVA" ]; then
+  export JAVA_HOME="$_AS_JAVA"
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+unset _AS_JAVA
 
+# asdf
 . "$(brew --prefix asdf)/libexec/asdf.sh"

--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -35,5 +35,3 @@ function gocover() {
   rm cover.out
   echo "generate cover.html"
 }
-
-alias claude="/Users/yamadaken/.claude/local/claude"

--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@ tap "grishka/grishka"
 tap "lihaoyun6/tap"
 brew "act"
 brew "anyenv"
+brew "asdf"
 brew "bash"
 ## AWS CLI is now managed by a separate script.
 brew "circleci"


### PR DESCRIPTION
## Summary
- ハードコードされた `/Users/yamadaken` を全て `\$HOME` に置き換え（4箇所）
- Android Studio の `JAVA_HOME` 設定をディレクトリ存在確認付きに変更（未インストール環境でも安全に動作）

## Test plan
- [x] `source ~/.zshrc` でエラーが出ないことを確認
- [x] Android Studio がない環境で `JAVA_HOME` が空のままであることを確認