### PR TITLE
feat: add OpenClaw completion and fix Python/asdf PATH setup

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -192,7 +192,5 @@ unset _AS_JAVA
 
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
-export PATH="$PATH:/Users/ken/Library/Python/3.9/bin"
-
 # OpenClaw Completion
 source "/Users/ken/.openclaw/completions/openclaw.zsh"

--- a/.zshrc
+++ b/.zshrc
@@ -188,7 +188,9 @@ fi
 unset _AS_JAVA
 
 # asdf
-. "$(brew --prefix asdf)/libexec/asdf.sh"
+if command -v brew &>/dev/null && [ -f "$(brew --prefix asdf)/libexec/asdf.sh" ]; then
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
+fi
 
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -187,6 +187,11 @@ if [ -d "$_AS_JAVA" ]; then
 fi
 unset _AS_JAVA
 
+# asdf
+_asdf_sh="$(brew --prefix asdf 2>/dev/null)/libexec/asdf.sh"
+[ -f "$_asdf_sh" ] && . "$_asdf_sh"
+unset _asdf_sh
+
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
 # OpenClaw Completion

--- a/.zshrc
+++ b/.zshrc
@@ -178,3 +178,7 @@ fi
 
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
+export PATH="$PATH:/Users/ken/Library/Python/3.9/bin"
+
+# OpenClaw Completion
+source "/Users/ken/.openclaw/completions/openclaw.zsh"

--- a/.zshrc
+++ b/.zshrc
@@ -187,11 +187,6 @@ if [ -d "$_AS_JAVA" ]; then
 fi
 unset _AS_JAVA
 
-# asdf
-if command -v brew &>/dev/null && [ -f "$(brew --prefix asdf)/libexec/asdf.sh" ]; then
-  . "$(brew --prefix asdf)/libexec/asdf.sh"
-fi
-
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
 # OpenClaw Completion

--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -36,4 +36,4 @@ function gocover() {
   echo "generate cover.html"
 }
 
-alias claude="/Users/yamadaken/.claude/local/claude"
+#alias claude="/Users/yamadaken/.claude/local/claude"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+Personal dotfiles for cross-platform development environment setup (macOS, Linux, Windows). Automates shell configuration, package installation, and tool setup.
+
+## Installation Flow
+
+```
+install.sh → setup.sh → mac_init.sh / linux_init.sh
+```
+
+- `install.sh` — detects OS, clones repo, dispatches to platform installer
+- `setup.sh` — installs packages (Homebrew/apt/dnf/yum/pacman/winget), symlinks dotfiles, installs anyenv
+- `mac_init.sh` / `linux_init.sh` — post-setup: iTerm2/Starship, Vim plugins, anyenv plugins, GitHub CLI config
+- `setup.ps1` — Windows: installs Starship, copies PowerShell profile
+
+## Platform Architecture
+
+| Concern | macOS | Linux | Windows |
+|---|---|---|---|
+| Shell | Zsh + Oh My Zsh | Bash | PowerShell |
+| Prompt | Powerlevel10k | Starship | Starship |
+| Packages | Brewfile | packages/{apt,dnf,pacman}.txt | winget_packages.ps1 |
+| Version mgr | anyenv | anyenv | — |
+
+## Key File Relationships
+
+- `.zshrc` sources `.zshenv` implicitly; both are symlinked to `$HOME` by `setup.sh`
+- `.zshrc.alias` is shared across platforms and sourced in both `.zshrc` and `.bashrc`
+- `starship.toml` is copied (not symlinked) to `~/.config/starship.toml` on Linux/Windows
+- `gh/config.yml` is symlinked to `~/.config/gh/config.yml`
+- `.bin/` directory is symlinked to `~/.bin/` and added to PATH in `.zshenv`
+
+## Shell Configuration Details
+
+**macOS `.zshrc`** loads in this order:
+1. Powerlevel10k instant prompt
+2. PATH additions (anyenv, Flutter, Android, MySQL, Cargo, LM Studio, `.bin`)
+3. Oh My Zsh (plugins: git, zsh-autosuggestions, zsh-completions, zsh-syntax-highlighting)
+4. `.zshrc.alias`
+5. Google Cloud SDK (multiple fallback paths for Homebrew vs manual install)
+6. Tool completions (Docker, etc.)
+
+**Linux `.bashrc`** includes color detection with `TERM=dumb` fallback to avoid broken terminals.
+
+## Optional Scripts (`scripts/`)
+
+These are not run automatically — invoke manually as needed:
+- `setup_gcloud.sh` — Google Cloud SDK (Homebrew, Python 3.14 compatibility)
+- `setup_aws.sh` / `setup_heroku.sh` — Cloud CLI tools
+- `setup_zsh.sh` — Oh My Zsh installation
+- `setup_editor_fonts.sh` — Configure MesloLGS NF font in VSCode, Cursor, Windsurf
+- `merge_editor_settings.sh` — Safe JSON merge (backs up existing settings, adds only missing keys)
+
+## Prompt / Theme
+
+- **macOS:** Powerlevel10k — requires MesloLGS NF font
+- **Linux/Windows:** Starship with Gruvbox Dark palette (`starship.toml`)
+- The starship config uses emoji directory substitutions and shows language versions (Node, Go, Rust, Python, PHP), Docker context, and time
+
+## Aliases (`.zshrc.alias`)
+
+- `ls`/`l`/`ll`/`la`/`et`/`lt` — `eza` wrappers (falls back to system `ls` if eza unavailable)
+- `mkdir` — always `-p`
+- `gocover()` — function to generate and open Go coverage reports in browser

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,22 @@ Personal dotfiles for cross-platform development environment setup (macOS, Linux
 ## Installation Flow
 
 ```
+# Universal (auto-detects OS)
 install.sh → setup.sh → mac_init.sh / linux_init.sh
+
+# macOS-specific
+install_mac.sh → setup.sh → mac_init.sh
+
+# Linux-specific
+install_linux.sh → setup.sh → linux_init.sh
+
+# Windows
+install.ps1 → setup.ps1
 ```
 
 - `install.sh` — detects OS, clones repo, dispatches to platform installer
-- `setup.sh` — installs packages (Homebrew/apt/dnf/yum/pacman/winget), symlinks dotfiles, installs anyenv
+- `install_mac.sh` / `install_linux.sh` — platform-specific entry points (clone + setup)
+- `setup.sh` — installs packages (Homebrew/apt/dnf/yum/pacman), symlinks dotfiles, installs anyenv
 - `mac_init.sh` / `linux_init.sh` — post-setup: iTerm2/Starship, Vim plugins, anyenv plugins, GitHub CLI config
 - `setup.ps1` — Windows: installs Starship, copies PowerShell profile
 
@@ -24,36 +35,61 @@ install.sh → setup.sh → mac_init.sh / linux_init.sh
 | Shell | Zsh + Oh My Zsh | Bash | PowerShell |
 | Prompt | Powerlevel10k | Starship | Starship |
 | Packages | Brewfile | packages/{apt,dnf,pacman}.txt | winget_packages.ps1 |
-| Version mgr | anyenv | anyenv | — |
+| Version mgr | anyenv + asdf | anyenv | — |
+| Alias file | `.zshrc.alias` | `.bashrc.alias` | — |
 
 ## Key File Relationships
 
 - `.zshrc` sources `.zshenv` implicitly; both are symlinked to `$HOME` by `setup.sh`
-- `.zshrc.alias` is shared across platforms and sourced in both `.zshrc` and `.bashrc`
+- `.zshrc.alias` is shared across platforms and sourced in both `.zshrc` and `.zshenv`
+- `.bashrc.alias` is the Linux/Bash equivalent of `.zshrc.alias`
 - `starship.toml` is copied (not symlinked) to `~/.config/starship.toml` on Linux/Windows
 - `gh/config.yml` is symlinked to `~/.config/gh/config.yml`
 - `.bin/` directory is symlinked to `~/.bin/` and added to PATH in `.zshenv`
+  - `showenv` — prints PATH entries one per line
+  - `cloud_sql_proxy` — Cloud SQL Proxy binary
 
 ## Shell Configuration Details
 
 **macOS `.zshrc`** loads in this order:
-1. Powerlevel10k instant prompt
-2. PATH additions (anyenv, Flutter, Android, MySQL, Cargo, LM Studio, `.bin`)
-3. Oh My Zsh (plugins: git, zsh-autosuggestions, zsh-completions, zsh-syntax-highlighting)
-4. `.zshrc.alias`
-5. Google Cloud SDK (multiple fallback paths for Homebrew vs manual install)
-6. Tool completions (Docker, etc.)
+1. Google Cloud SDK (multiple fallback paths for Homebrew vs manual install)
+2. Powerlevel10k instant prompt preamble
+3. Android Studio IntelliJ env check (`ZSH_TMUX_AUTOSTART`)
+4. Oh My Zsh (plugins: git, zsh-autosuggestions, zsh-completions, zsh-syntax-highlighting)
+5. `.zshrc.alias`
+6. iTerm2 Shell Integration
+7. Docker CLI completions
+8. LM Studio CLI PATH
+9. kiro shell integration
+10. p10k config (`~/.p10k.zsh`)
+11. anyenv init (with guard: only if `~/.anyenv` exists)
+12. Android Studio Java PATH (with guard: only if Android Studio installed)
+13. asdf init (with guard: only if `$(brew --prefix asdf)/libexec/asdf.sh` exists)
+14. Antigravity PATH
+15. OpenClaw shell completion
 
 **Linux `.bashrc`** includes color detection with `TERM=dumb` fallback to avoid broken terminals.
 
 ## Optional Scripts (`scripts/`)
 
 These are not run automatically — invoke manually as needed:
-- `setup_gcloud.sh` — Google Cloud SDK (Homebrew, Python 3.14 compatibility)
-- `setup_aws.sh` / `setup_heroku.sh` — Cloud CLI tools
-- `setup_zsh.sh` — Oh My Zsh installation
-- `setup_editor_fonts.sh` — Configure MesloLGS NF font in VSCode, Cursor, Windsurf
-- `merge_editor_settings.sh` — Safe JSON merge (backs up existing settings, adds only missing keys)
+
+| Script | Purpose |
+|--------|---------|
+| `setup_gcloud.sh` | Google Cloud SDK (Homebrew, Python 3.14 compatibility) |
+| `setup_aws.sh` | AWS CLI setup |
+| `setup_heroku.sh` | Heroku CLI setup |
+| `setup_node.sh` | Node.js via nvm |
+| `setup_zsh.sh` | Oh My Zsh installation |
+| `setup_editor_fonts.sh` | Configure MesloLGS NF font in VSCode, Cursor, Windsurf |
+| `setup_cursor_fonts.sh` | Configure fonts for Cursor only |
+| `setup_vscode_fonts.sh` | Configure fonts for VSCode only |
+| `setup_windsurf_fonts.sh` | Configure fonts for Windsurf only |
+| `setup_terminal_fonts.sh` | Configure fonts for Terminal.app and iTerm2 |
+| `setup_iterm2_profile.sh` | Create iTerm2 profile with font settings |
+| `merge_editor_settings.sh` | Safe JSON merge (backs up existing settings, adds only missing keys) |
+
+Editor settings templates: `cursor_settings.json`, `vscode_settings.json`, `windsurf_settings.json`
 
 ## Prompt / Theme
 
@@ -65,4 +101,4 @@ These are not run automatically — invoke manually as needed:
 
 - `ls`/`l`/`ll`/`la`/`et`/`lt` — `eza` wrappers (falls back to system `ls` if eza unavailable)
 - `mkdir` — always `-p`
-- `gocover()` — function to generate and open Go coverage reports in browser
+- `gocover()` — function to generate Go coverage HTML report


### PR DESCRIPTION
## Summary

- OpenClaw のシェル補完を追加
- ハードコードされた Python 3.9 の PATH を削除（pipx への移行）
- asdf 初期化を Powerlevel10k の instant prompt と互換性のある形に修正（未インストール環境ではスキップ）

## Changes

- `.zshrc`: OpenClaw completion を追加
- `.zshrc`: Python 3.9 bin の hardcoded PATH を削除
- `.zshrc`: asdf 初期化に guard を追加（`brew --prefix` のエラー出力を抑制）

Made with [Cursor](https://cursor.com)