### PR TITLE
fix: openclaw未インストール環境でシェル起動エラーにならないよう対応

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -195,4 +195,4 @@ unset _asdf_sh
 # Added by Antigravity
 export PATH="/Users/ken/.antigravity/antigravity/bin:$PATH"
 # OpenClaw Completion
-source "/Users/ken/.openclaw/completions/openclaw.zsh"
+[[ -f "/Users/ken/.openclaw/completions/openclaw.zsh" ]] && source "/Users/ken/.openclaw/completions/openclaw.zsh"


### PR DESCRIPTION
## Summary

- `.zshrc` の openclaw completion の `source` 前にファイル存在チェック (`[[ -f ... ]]`) を追加
- openclaw がインストールされていない環境でもシェルが正常に起動するようになる

## 変更内容

```diff
- source "/Users/ken/.openclaw/completions/openclaw.zsh"
+ [[ -f "/Users/ken/.openclaw/completions/openclaw.zsh" ]] && source "/Users/ken/.openclaw/completions/openclaw.zsh"
```

## Test plan

- [ ] openclaw がインストールされた環境でシェル起動・補完が正常に動作すること
- [ ] openclaw がインストールされていない環境でシェルがエラーなく起動すること

Made with [Cursor](https://cursor.com)