### PR TITLE
fix: update renamed casks in Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -56,12 +56,12 @@ cask "font-meslo-lg-nerd-font"
 cask "font-hack-nerd-font"
 cask "font-hackgen"
 cask "font-hackgen-nerd"
-cask "google-cloud-sdk", args: { adopt: true }
+cask "gcloud-cli", args: { adopt: true }
 cask "iterm2", args: { adopt: true, greedy: false }
 cask "logoer", args: { adopt: true }
 cask "neardrop", args: { adopt: true }
 cask "transmit", args: { appdir: "/Applications", adopt: true }
-cask "xcodes", args: { adopt: true }
+cask "xcodes-app", args: { adopt: true }
 cask "zoom", args: { adopt: true, greedy: false }
 
 mas "GarageBand", id: 682658836


### PR DESCRIPTION
## Summary

- `google-cloud-sdk` → `gcloud-cli`
- `xcodes` → `xcodes-app`

Homebrew がこれらの cask 名を変更したため、`brew bundle` 実行時に Warning が出ていた。

## Test plan

- [ ] `brew bundle --no-upgrade` で Warning が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)