### PR TITLE
fix: DOTPATH フォールバックを mac_init.sh / linux_init.sh に追加

### DIFF
--- a/linux_init.sh
+++ b/linux_init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DOTPATH="${DOTPATH:-$HOME/dotfiles}"
+
 if [ "$(uname)" != "Linux" ] ; then
 	echo "Not Linux!"
 	exit 1

--- a/mac_init.sh
+++ b/mac_init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DOTPATH="${DOTPATH:-$HOME/dotfiles}"
+
 if [ "$(uname)" != "Darwin" ] ; then
 	echo "Not macOS!"
 	exit 1


### PR DESCRIPTION
## Summary

- `mac_init.sh` / `linux_init.sh` を `setup.sh` 経由でなく直接実行した場合、`DOTPATH` が未定義で `/scripts/setup_gcloud.sh` のようなパスになりエラーになっていた
- 先頭に `DOTPATH="${DOTPATH:-$HOME/dotfiles}"` を追加してフォールバックを設定

## Test plan

- [ ] `bash ~/dotfiles/mac_init.sh` を直接実行してエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)